### PR TITLE
Added new color formats

### DIFF
--- a/ColorPicker.nuspec
+++ b/ColorPicker.nuspec
@@ -2,14 +2,14 @@
 <package>
   <metadata>
     <id>ColorPicker</id>
-    <version>1.2.0</version>
+    <version>1.2.1</version>
     <authors>Martin Chrzan</authors>
     <owners>Martin Chrzan</owners>
     <licenseUrl>https://github.com/martinchrzan/ColorPicker/blob/master/LICENSE</licenseUrl>
     <projectUrl>http://github.com/martinchrzan/ColorPicker</projectUrl>
     <!--<iconUrl></iconUrl>-->
     <releaseNotes>
-       Added color meter feature
+       Added new color formats - RGB565, decimal big-endian, decimal little-endian
     </releaseNotes>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Color Picker</description>

--- a/ColorPicker/Helpers/ColorFormatHelper.cs
+++ b/ColorPicker/Helpers/ColorFormatHelper.cs
@@ -1,5 +1,6 @@
 ﻿using ColorPicker.Settings;
 using System;
+using System.Drawing;
 using System.Globalization;
 
 namespace ColorPicker.Helpers
@@ -21,9 +22,42 @@ namespace ColorPicker.Helpers
                     return ColorToRgb(c);
                 case ColorFormat.vec4:
                     return ColorToVec4(c);
+                case ColorFormat.rgb565:
+                    return ColorToRgb565(c);
+                case ColorFormat.decimalLE:
+                    return ColorToDecimalLE(c);
+                case ColorFormat.decimalBE:
+                    return ColorToDecimalBE(c);
                 default:
                     return string.Empty;
             }
+        }
+
+        // big-endian
+        private static string ColorToDecimalBE(Color c)
+        {
+            return ((c.R * 265 * 265) + (c.G * 256) + c.B).ToString();
+        }
+
+        // little-endian
+        private static string ColorToDecimalLE(Color c)
+        {
+            return ((c.B * 265 * 265) + (c.G * 256) + c.R).ToString();
+        }
+
+        private static string ColorToRgb565(Color c)
+        {
+            // Shift the red value to the leftmost 5 bits
+            ushort r = (ushort)(c.R >> 3);
+            // Shift the green value to the middle 6 bits
+            ushort g = (ushort)(c.G >> 2);
+            // Shift the blue value to the rightmost 5 bits
+            ushort b = (ushort)(c.B >> 3);
+
+            // Combine the shifted values into a single 16-bit value
+            ushort rgb565 = (ushort)((r << 11) | (g << 5) | b);
+
+            return "#" + rgb565.ToString("X2", CultureInfo.InvariantCulture);
         }
 
         private static string ColorToHex(System.Drawing.Color c)
@@ -39,8 +73,8 @@ namespace ColorPicker.Helpers
         private static string ColorToHsl(System.Drawing.Color c)
         {
             var h = Math.Round(c.GetHue());
-            var s = Math.Round(c.GetSaturation()*100);
-            var l = Math.Round(c.GetBrightness()*100);
+            var s = Math.Round(c.GetSaturation() * 100);
+            var l = Math.Round(c.GetBrightness() * 100);
             return "hsl(" + h + ", " + s + "%, " + l + "%)";
         }
 
@@ -53,12 +87,12 @@ namespace ColorPicker.Helpers
             var s = (max == 0) ? 0 : 1d - (1d * min / max);
             var v = max / 255d;
 
-            return "hsv(" + h + ", " + Math.Round(s*100) + ", " + Math.Round(v*100) + ")";
+            return "hsv(" + h + ", " + Math.Round(s * 100) + ", " + Math.Round(v * 100) + ")";
         }
 
         private static string ColorToVec4(System.Drawing.Color c)
         {
-            return string.Format("vec4({0}, {1}, {2}, 1)", Math.Round(c.R / 255f, 3), Math.Round(c.G / 255f, 3), Math.Round(c.B / 255f, 3));  
+            return string.Format("vec4({0}, {1}, {2}, 1)", Math.Round(c.R / 255f, 3), Math.Round(c.G / 255f, 3), Math.Round(c.B / 255f, 3));
         }
     }
 }

--- a/ColorPicker/Properties/AssemblyInfo.cs
+++ b/ColorPicker/Properties/AssemblyInfo.cs
@@ -1,6 +1,4 @@
 ﻿using System.Reflection;
-using System.Resources;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Windows;
 
@@ -50,6 +48,6 @@ using System.Windows;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.2.0.0")]
-[assembly: AssemblyFileVersion("1.2.0.0")]
+[assembly: AssemblyVersion("1.2.1.0")]
+[assembly: AssemblyFileVersion("1.2.1.0")]
 [assembly: AssemblyMetadata("SquirrelAwareVersion", "1")]

--- a/ColorPicker/Settings/IUserSettings.cs
+++ b/ColorPicker/Settings/IUserSettings.cs
@@ -3,7 +3,7 @@ using System.Drawing;
 
 namespace ColorPicker.Settings
 {
-    public enum ColorFormat { hex, rgb, hsl, hsv, vec4};
+    public enum ColorFormat { hex, rgb, hsl, hsv, vec4, rgb565, decimalBE, decimalLE};
 
     public interface IUserSettings
     {

--- a/ColorPicker/ViewModels/MainViewModel.cs
+++ b/ColorPicker/ViewModels/MainViewModel.cs
@@ -7,12 +7,9 @@ using ColorPicker.Settings;
 using ColorPicker.ViewModelContracts;
 using System;
 using System.ComponentModel.Composition;
-using System.Globalization;
-using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Media;
-using System.Windows.Threading;
 
 namespace ColorPicker.ViewModels
 {

--- a/ColorPicker/Views/SettingsView.xaml
+++ b/ColorPicker/Views/SettingsView.xaml
@@ -34,7 +34,7 @@
             <Rectangle Height="1" Fill="DarkGray" Margin="5"/>
             <WrapPanel>
                 <TextBlock VerticalAlignment="Center" Style="{StaticResource NormalTextBlock}" FontWeight="Light" Margin="7" Text="Copied color format:"/>
-                <ComboBox Margin="5" SelectedItem="{Binding SelectedColorFormat}" ItemsSource="{Binding Source={StaticResource colorFormat}}" Width="90"/>
+                <ComboBox Margin="5" SelectedItem="{Binding SelectedColorFormat}" ItemsSource="{Binding Source={StaticResource colorFormat}}"/>
             </WrapPanel>
 
             <Rectangle Height="1" Fill="DarkGray" Margin="5"/>

--- a/README.md
+++ b/README.md
@@ -33,9 +33,12 @@ Currently supported color formats and their string representation:
 - **HSL** - *hsl(0, 0%, 12%)* 
 - **HSV** - *hsv(0, 0, 12)*
 - **VEC4** - *vec4(0.122, 0.122, 0.122, 1)*
+- **RGB565** - *#4C8A*
+- **DecimalBE (Big-endian)** - *2114460*
+- **DecimalLE (Little-endian)** - *1213756*
 
 ## Differences from the implementation in PowerToys
-- different set of color formats, vec4 is only here, however there are some missing
+- different set of supported color formats
 - color meter feature (average color of an area)
 - quick colors history palette
 - different design


### PR DESCRIPTION
Added new color formats - rgb565, decimal big-endian, decimal little-endian.

Resolves
https://github.com/martinchrzan/ColorPicker/issues/17
https://github.com/martinchrzan/ColorPicker/issues/16
